### PR TITLE
Deprecate use of Ska.ParseCM

### DIFF
--- a/Ska/ParseCM.py
+++ b/Ska/ParseCM.py
@@ -1,6 +1,11 @@
 import Chandra.Time
 import re
 from six.moves import filter
+import warnings
+
+# Warn about deprecation but use FutureWarning so it actually shows up (since
+# DeprecationWarning is ignored by default)
+warnings.warn('Ska.ParseCM is deprecated, use parse_cm instead', FutureWarning)
 
 import ska_helpers
 
@@ -57,9 +62,9 @@ def read_backstop(filename):
     paramstr  char
     tlmsid    char
     msid      char
-    vcdu      int 
-    step      int 
-    scs       int 
+    vcdu      int
+    step      int
+    scs       int
     ========= ======
 
     :param filename: Backstop file name
@@ -116,7 +121,7 @@ def read_mm(filename):
     mm_text = open(filename).read()
     mm_blocks = mm_text.split("MANEUVER DATA SUMMARY\n")
     manvr_blocks = [x for x in mm_blocks if "INITIAL" in x or "FINAL" in x]
-    
+
     int_obsid = 'IN_IA'
 
     att_re_dict = { 'obsid': re.compile("ID:\s+(\S+)\S\S"),
@@ -145,7 +150,7 @@ def read_mm(filename):
         outdata_check = re.compile("OUTPUT DATA")
         outdata_match = list(filter( outdata_check.search, para))
         output_data = outdata_match[0]
-        
+
         att_text = { 'initial': att_chunks[0],
                      'final': att_chunks[1] }
 


### PR DESCRIPTION
## Description

Per the email from June 10 "Package deprecations: Chandra.cmd_states and Ska.ParseCM", deprecate this package with a message that gets displayed upon import.

## Testing

- [N/A] Passes unit tests on MacOS (tests do not run on MacOS)
- [x] Functional testing

```
(ska3) ➜  Ska.ParseCM git:(master) ✗ python -c 'import Ska.ParseCM; print(Ska.ParseCM.__file__)'
./Ska/ParseCM.py:8: FutureWarning: Ska.ParseCM is deprecated, use parse_cm instead
  warnings.warn('Ska.ParseCM is deprecated, used parse_cm instead', FutureWarning)
./Ska/ParseCM.py
```

cc: @jzuhone 

NOTE: this will be promoted after July 10.
