### PR TITLE
Discontinue package

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,9 @@
 :mod:`ska_parsecm`
 ========================
 
+.. Warning:: the ska_parsecm package is **discontinued and no longer supported**.
+    Instead use `parse_cm <https://sot.github.io/parse_cm/>`.
+
+
 .. automodule:: ska_parsecm.ParseCM
    :members:

--- a/ska_parsecm/__init__.py
+++ b/ska_parsecm/__init__.py
@@ -1,4 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+import warnings
+
+message_warn = (
+    "\n"
+    "The ska_parsecm package is no longer supported and is replaced\n"
+    "by parse_cm. Please update your code accordingly.\n"
+)
+message_error = (
+    "\n"
+    "To temporarily continue using this package set the environment variable\n"
+    "SKA_ALLOW_DISCONTINUED_PACKAGES=1"
+)
+
+if os.environ.get("SKA_ALLOW_DISCONTINUED_PACKAGES") == "1":
+    warnings.warn(message_warn, FutureWarning)
+else:
+    raise RuntimeError(message_warn + message_error)
 
 import ska_helpers
 


### PR DESCRIPTION
## Description

This addresses one action in https://github.com/sot/kadi/issues/230.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Importing package raises an exception unless `SKA_ALLOW_DISCONTINUED_PACKAGES=1`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
No testing on discontinued package.

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.

```
(ska3) ➜  ska_parsecm git:(master) ✗ ipython
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import ska_parse_cm
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[1], line 1
----> 1 import ska_parse_cm

ModuleNotFoundError: No module named 'ska_parse_cm'

In [2]: import ska_parsecm
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[2], line 1
----> 1 import ska_parsecm

File ~/git/ska_parsecm/ska_parsecm/__init__.py:19
     17     warnings.warn(message_warn, FutureWarning)
     18 else:
---> 19     raise RuntimeError(message_warn + message_error)
     21 import ska_helpers
     23 from .ParseCM import *  # noqa

RuntimeError: 
The ska_parsecm package is no longer supported and is replaced
by parse_cm. Please update your code accordingly.

To temporarily continue using this package set the environment variable
SKA_ALLOW_DISCONTINUED_PACKAGES=1

In [3]: import os

In [4]: os.environ["SKA_ALLOW_DISCONTINUED_PACKAGES"] = "1"

In [5]: import ska_parsecm
/Users/aldcroft/git/ska_parsecm/ska_parsecm/__init__.py:17: FutureWarning: 
The ska_parsecm package is no longer supported and is replaced
by parse_cm. Please update your code accordingly.

  warnings.warn(message_warn, FutureWarning)
/Users/aldcroft/git/ska_parsecm/ska_parsecm/ParseCM.py:8: FutureWarning: ska_parsecm is deprecated, use parse_cm instead
  warnings.warn('ska_parsecm is deprecated, use parse_cm instead', FutureWarning)

In [6]:                                                                                                                                                      
```
